### PR TITLE
fix(Maybe): method .or should return this on just

### DIFF
--- a/src/Maybe.js
+++ b/src/Maybe.js
@@ -75,7 +75,7 @@ class MaybeJust<+T> implements Maybe<T> {
   }
 
   or<T1>(): Maybe<T1> {
-    return nothing;
+    return this;
   }
 
   alt<T1>(): Maybe<T | T1> {


### PR DESCRIPTION
`just(1).or(just(2))` should return `just(1)`
like js:
```1 || 2 === 1```